### PR TITLE
Make @auto assets work

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,9 +10,15 @@ Kirby::plugin('bvdputte/fingerprint', [
     ],
     'components' => [
         'css' => function ($kirby, $url, $options) {
+            if ($url === '@auto') {
+                $url = \Kirby\Cms\Url::toTemplateAsset('css/templates', 'css');
+            }
             return bvdputte\Fingerprint::addHash($url);
         },
         'js' => function ($kirby, $url, $options) {
+            if ($url === '@auto') {
+                $url = \Kirby\Cms\Url::toTemplateAsset('js/templates', 'js');
+            }
             return bvdputte\Fingerprint::addHash($url);
         },
     ]

--- a/src/Fingerprint.php
+++ b/src/Fingerprint.php
@@ -1,12 +1,17 @@
 <?php
 
 namespace bvdputte;
-use Kirby\Cms\Url;
+use Kirby\Cms\App;
+use Kirby\Http\Url;
 
 class Fingerprint
 {
     public static function addHash($path)
     {
+        if (Url::isAbsolute($path)) {
+            $path = Url::path($path);
+        }
+
         if ( ! file_exists($path) || count($pathinfo = pathinfo($path)) < 4) {
             return $path;
         }


### PR DESCRIPTION
Hi there, 

first of all thanks a lot for your plugin. It is as as simply as the cachebuster plugin for Kirby 2 and that is what I like about it :-)

I would like to use it in an upcoming project, however it was missing the support for @auto templates. As long as [getkirby/kirby::1608](https://github.com/getkirby/kirby/issues/1608) is not fixed, this PR makes @auto assets work. 

Please be aware, that the changes made to Fingerprint.php are necessary nonetheless, even when 1608 is fixed: In your addHash method you are currently working with paths. However, the css and js helpers works with absolute urls, too. In this case https://github.com/bvdputte/kirby-fingerprint/compare/master...presprog:feature/@auto-assets#diff-de63c4a79f953aee3228edcf6479c9ccR15 will always return false. The additional check for an absolute url fixes that. 

Cheerio