### PR TITLE
Check for external Scripts

### DIFF
--- a/src/Fingerprint.php
+++ b/src/Fingerprint.php
@@ -9,6 +9,11 @@ class Fingerprint
     public static function addHash($path)
     {
         if (Url::isAbsolute($path)) {
+            
+            if (Url::toObject()->host() !== Url::toObject($path)->host()) {
+                return $path;
+            }
+            
             $path = Url::path($path);
         }
 


### PR DESCRIPTION
External scripts break, because the hostname gets stripped and replaced with the current hostname.

```js
js([
  "https://cdn.jsdelivr.net/npm/cash-dom@8.1.0/dist/cash.min.js",
  "/assets/js/app.js",
  "@auto"
])
```